### PR TITLE
Adding some post to the Blog about EthernalCurse

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the infrastructure as code and documentation for the Connected Community Hacker Space, Melbourne.
 
-Make sure you have [`pre-commit`](https://github.com/pre-commit/) locally installed before commiting to this repository.
+Make sure you have [`pre-commit`](https://github.com/pre-commit/) locally installed before committing to this repository.
 
 ## Ground rules
 

--- a/docs/blog/3-ethernalcurse-rethinking-raid.md
+++ b/docs/blog/3-ethernalcurse-rethinking-raid.md
@@ -1,0 +1,28 @@
+# EthernalCurse: Rethinking RAID
+
+Coming from a debate in the infrastructure discord channel for CCHS, we have loosely decided to undo the built in RAID and proceed instead with a ZFS pool.
+
+This has the drawback that we will loose some performance but will break us free from the built in RAID Controller in case of a failure, making it easier to recover in case of a hardware issue.
+
+As we do not have any service or VM running on EthernalCurse, it is a painless moment to take this action.
+
+## Undoing the RAID
+
+First of all, we should do some reading
+
+- [RAID configuration](https://www.programmersought.com/article/56481068366/).
+- [On the topic of disabling the RAID](https://serverfault.com/questions/295578/how-to-disable-the-built-in-RAID-in-x3650-m3)
+
+1. Enter in the "WebBIOS" `ctr + H`. Waiting until the boot has started after any network boot has timed out
+2. Note down RAID configuration (RAID 5)
+3. Clear the RAID configuration
+4. It is not possible to Disable the RAID. The workaround is to set every disk as an independent Drive Group
+   - Raid level 0
+   - Write Policy: Write Through
+   - IO Policy: Direct
+5. Add one by one the Drive groups to an individual span
+6. Make the first drive Bootable
+
+## Next steps
+
+Once Proxmox is installed in the first drive, I will create a ZFS Pool with the remaining disks in RAID-Z1. More on this in the next post.

--- a/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
+++ b/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
@@ -1,0 +1,15 @@
+# EthernalCurse: Reinstalling Proxmox with a ZFS Pool
+
+First steps are simple. Download latest version of Proxmox, copy it to an USB drive with [Ventoy](https://www.ventoy.net/en/index.html) and boot on usb device (F12 in IBM boot screen).
+
+## Basic Installation
+
+Country: Australia
+Timezone: UTC
+eno1 (first ethernet port and yellow cable marked as 1) as administrative interface
+Hostname: ethernalcurse.local
+Address: 192.168.70.126/24 (IBM IMM is 192.168.70.125/24)
+Gateway: 192.168.70.1 (bad)
+DNS: 1.1.1.1 (wont work with bad gateway)
+
+Password: (Not to be shared in any of the documentation, of course)

--- a/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
+++ b/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
@@ -41,7 +41,7 @@ sdf                  8:80   0 930.4G  0 disk
 sdg                  8:96   0 930.4G  0 disk
 ```
 
-the zpool is created as:
+The zpool is created as:
 
 `zpool create storagepool raidz1 /dev/sdb /dev/sdc /dev/sdd /dev/sde /dev/sdf /dev/sdg`
 
@@ -64,4 +64,12 @@ config:
 errors: No known data errors
 ```
 
-the pool has been mounted in `/storagepool/`
+**The pool has been mounted in `/storagepool/`**
+
+## Segmenting the pool: Datasets
+
+To start, I have added two dataset to the storage pool, vs-disks, isos and backups. Adding them is trivial eg.`zfs create mypool/vm-disks`.
+
+## Next steps
+
+- Configuring the storage in Proxmox to make use of the ZFS Pool.

--- a/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
+++ b/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
@@ -13,3 +13,6 @@ Gateway: 192.168.70.1 (bad)
 DNS: 1.1.1.1 (wont work with bad gateway)
 
 Password: (Not to be shared in any of the documentation, of course)
+
+## getting the ZFS RAID-Z1 up and running
+

--- a/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
+++ b/docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md
@@ -16,3 +16,52 @@ Password: (Not to be shared in any of the documentation, of course)
 
 ## getting the ZFS RAID-Z1 up and running
 
+RAID-Z1 will give us fault tolerance for 1 drive. Meaning that the system will maintain information integrity if one drive gets corrupted or missing.
+
+Given the next hardware configuration:
+
+```bash
+root@ethernalcurse:~# lsblk
+NAME               MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
+sda                  8:0    0 930.4G  0 disk
+├─sda1               8:1    0  1007K  0 part
+├─sda2               8:2    0     1G  0 part /boot/efi
+└─sda3               8:3    0 929.4G  0 part
+  ├─pve-swap       252:0    0     8G  0 lvm  [SWAP]
+  ├─pve-root       252:1    0    96G  0 lvm  /
+  ├─pve-data_tmeta 252:2    0   8.1G  0 lvm
+  │ └─pve-data     252:4    0 793.2G  0 lvm
+  └─pve-data_tdata 252:3    0 793.2G  0 lvm
+    └─pve-data     252:4    0 793.2G  0 lvm
+sdb                  8:16   0 930.4G  0 disk
+sdc                  8:32   0 930.4G  0 disk
+sdd                  8:48   0 930.4G  0 disk
+sde                  8:64   0 930.4G  0 disk
+sdf                  8:80   0 930.4G  0 disk
+sdg                  8:96   0 930.4G  0 disk
+```
+
+the zpool is created as:
+
+`zpool create storagepool raidz1 /dev/sdb /dev/sdc /dev/sdd /dev/sde /dev/sdf /dev/sdg`
+
+```bash
+root@ethernalcurse:~# zpool status
+  pool: storagepool
+ state: ONLINE
+config:
+
+        NAME         STATE     READ WRITE CKSUM
+        storagepool  ONLINE       0     0     0
+          raidz1-0   ONLINE       0     0     0
+            sdb      ONLINE       0     0     0
+            sdc      ONLINE       0     0     0
+            sdd      ONLINE       0     0     0
+            sde      ONLINE       0     0     0
+            sdf      ONLINE       0     0     0
+            sdg      ONLINE       0     0     0
+
+errors: No known data errors
+```
+
+the pool has been mounted in `/storagepool/`

--- a/docs/blog/5-ethernalcurse-configuring-storage-proxmox.md
+++ b/docs/blog/5-ethernalcurse-configuring-storage-proxmox.md
@@ -1,0 +1,10 @@
+# EthernalCurse: Configuring storage in Proxmox
+
+In this step I need to learn about the storage needs for Proxmox. Still gathering references.
+
+- Key location: `/etc/pve/storage.cfg`
+
+## References
+
+[Proxmox VE Docs: Storage](https://pve.proxmox.com/pve-docs/chapter-pvesm.html)
+[Proxmox VE Docs: Storage ](https://pve.proxmox.com/pve-docs/chapter-pvesm.html#_storage_configuration)

--- a/docs/equipment.md
+++ b/docs/equipment.md
@@ -12,7 +12,8 @@ Two multihomed machines, one with a large-ish hardware RAID5 disk array and the 
 
 [IBM x3650 M3](https://lenovopress.lenovo.com/tips0805-system-x3650-m3)
 
-/!\ WARNING: DIMM on slot 24 flagged as faulty.
+/!\ ~~WARNING: DIMM on slot 24 flagged as faulty.~~
+/!\ WARNING: DIMM on slot 17 flagged as faulty.
 
 Main machine in the ProxMox cluster:
 

--- a/docs/equipment.md
+++ b/docs/equipment.md
@@ -12,8 +12,8 @@ Two multihomed machines, one with a large-ish hardware RAID5 disk array and the 
 
 [IBM x3650 M3](https://lenovopress.lenovo.com/tips0805-system-x3650-m3)
 
-/!\ ~~WARNING: DIMM on slot 24 flagged as faulty.~~
 /!\ WARNING: DIMM on slot 17 flagged as faulty.
+/!\ WARNING: Disk 8 marked as "Unconfigured Bad" in WebBIOS.
 
 Main machine in the ProxMox cluster:
 


### PR DESCRIPTION
**Yes, I generated the pull request comment with Copilot**:

This pull request includes several updates to the documentation, primarily focusing on the EthernalCurse project. The changes range from fixing a minor typo to adding new blog posts and updating equipment status.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Corrected a typo from "commiting" to "committing".

New blog posts:

* [`docs/blog/3-ethernalcurse-rethinking-raid.md`](diffhunk://#diff-c4eca43c9709ea8f37132b075954b3312acb8aa5d0016ebef5b06ca09739a74bR1-R28): Added a new blog post discussing the decision to move from built-in RAID to a ZFS pool.
* [`docs/blog/4-ethernalcurse-installing-proxmox-n-zfs.md`](diffhunk://#diff-f1ebcd676244baa534a5c82edb180ce93c036c846d5b14f7e7e2c09dc64879caR1-R75): Added a detailed guide on reinstalling Proxmox with a ZFS pool, including step-by-step instructions and configuration details.
* [`docs/blog/5-ethernalcurse-configuring-storage-proxmox.md`](diffhunk://#diff-801e5c1c78918af4a3f5684ee6bbf8288685408139c4c11dfbb398138b4545acR1-R10): Added an initial blog post about configuring storage in Proxmox, with references for further reading.

Equipment status update:

* [`docs/equipment.md`](diffhunk://#diff-0c7f6bcd7b58f8231275a1826ded783b33a4a36bdcafdfd9c16af6bace96d952L15-R16): Updated the equipment status to indicate that DIMM slot 17 is flagged as faulty and Disk 8 is marked as "Unconfigured Bad" in WebBIOS.